### PR TITLE
fix(quality:pngs): don't apply quality option to lossless pngs

### DIFF
--- a/lib/crop.js
+++ b/lib/crop.js
@@ -29,11 +29,14 @@ class Crop extends DarkroomStream {
         .autoOrient()
         .colorspace('RGB')
         .gravity(this.gravity)
-        .quality(this.quality)
         .noProfile()
         .bitdepth(8)
         .unsharp(0.25, 0.25, 8, 0.065)
         .crop(this.crop.w, this.crop.h, this.crop.x1, this.crop.y1)
+
+      if (imageFileType.ext !== 'png') {
+        context = context.quality(this.quality)
+      }
 
       if (imageFileType.ext === 'jpg') {
         // This makes it progressive

--- a/lib/resize.js
+++ b/lib/resize.js
@@ -138,7 +138,10 @@ class Resize extends DarkroomStream {
       .noProfile()
       .bitdepth(8)
       .unsharp(0.25, 0.25, 8, 0.065)
-      .quality(this.quality)
+
+    if (outputFileType.ext !== 'png') {
+      context = context.quality(this.quality)
+    }
 
     context = this._setTypeSpecificOptions(
       context,


### PR DESCRIPTION
Fixes https://github.com/clocklimited/Darkroom-api/issues/51 on cropping and resizing (which is 99% of the currently DR usage).

Important to note that on `resize` (which can change the file format of an image), I use `outputFileType`. On `crop` (which doesn't change the file format), I use `imageFileType.ext`.